### PR TITLE
No SWITCH_FRAME Actions when playing Energizer

### DIFF
--- a/cvat-ui/src/utils/is-able-to-change-frame.ts
+++ b/cvat-ui/src/utils/is-able-to-change-frame.ts
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: MIT
 
 import { getCVATStore } from 'cvat-store';
+import { EnergizerType } from 'gamification/gamif-interfaces';
 import { CombinedState } from 'reducers/interfaces';
 
 export default function isAbleToChangeFrame(): boolean {
@@ -10,6 +11,15 @@ export default function isAbleToChangeFrame(): boolean {
 
     const state: CombinedState = store.getState();
     const { instance } = state.annotation.canvas;
+    const { activeEnergizer } = state.energizer; // To check energizer state
+
+    // Debug Code
+    console.log(`State of the activeEnergizer: ${activeEnergizer}`);
+    console.log(`EnergizerType== None? : ${activeEnergizer === EnergizerType.NONE}`);
+
     return !!instance && instance.isAbleToChangeFrame() &&
-        !state.annotation.player.navigationBlocked;
+        !state.annotation.player.navigationBlocked &&
+        // From here on additional conditions to prevent Frame-Changes when playing an Energizer-Game
+        !!activeEnergizer &&
+        activeEnergizer === EnergizerType.NONE;
 }


### PR DESCRIPTION
<!---
Copyright (C) 2020-2022 Intel Corporation

SPDX-License-Identifier: MIT
-->

<!-- Raised an issue to propose your change (https://github.com/opencv/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [CONTRIBUTION](https://github.com/opencv/cvat/blob/develop/CONTRIBUTING.md)
guide. -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable by a reason then ~~explicitly strikethrough~~ the whole
line. If you don't do that github will show an incorrect process for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I submit my changes into the `develop` branch
- [ ] I have added a description of my changes into [CHANGELOG](https://github.com/opencv/cvat/blob/develop/CHANGELOG.md) file
- [ ] I have updated the [documentation](
  https://github.com/opencv/cvat/blob/develop/README.md#documentation) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues ([read github docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
[cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning), [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))

### License

- [ ] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2022 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
